### PR TITLE
Add Table Exists Functionality

### DIFF
--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryBaseSink.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryBaseSink.java
@@ -66,6 +66,11 @@ abstract class BigQueryBaseSink<IN> implements Sink<IN> {
         if (sinkConfig.getSchemaProvider() == null) {
             throw new IllegalArgumentException("BigQuery schema provider cannot be null");
         }
+        // Destination table does not exist and connector cannot create new table.
+        if (sinkConfig.getSchemaProvider().schemaUnknown() && !sinkConfig.enableTableAutoCreate()) {
+            logger.error("TODO");
+            throw new IllegalStateException("TODO");
+        }
     }
 
     /** Ensures Sink's parallelism does not exceed the allowed maximum when scaling Flink job. */

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfig.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfig.java
@@ -53,6 +53,7 @@ public class BigQuerySinkConfig {
     private final DeliveryGuarantee deliveryGuarantee;
     private final BigQuerySchemaProvider schemaProvider;
     private final BigQueryProtoSerializer serializer;
+    private final boolean enableTableAutoCreate;
 
     public static Builder newBuilder() {
         return new Builder();
@@ -78,7 +79,8 @@ public class BigQuerySinkConfig {
         BigQuerySinkConfig object = (BigQuerySinkConfig) obj;
         if (this.getConnectOptions() == object.getConnectOptions()
                 && (this.getSerializer().getClass() == object.getSerializer().getClass())
-                && (this.getDeliveryGuarantee() == object.getDeliveryGuarantee())) {
+                && (this.getDeliveryGuarantee() == object.getDeliveryGuarantee())
+                && (this.enableTableAutoCreate() == object.enableTableAutoCreate())) {
             BigQuerySchemaProvider thisSchemaProvider = this.getSchemaProvider();
             BigQuerySchemaProvider objSchemaProvider = object.getSchemaProvider();
             return thisSchemaProvider.getAvroSchema().equals(objSchemaProvider.getAvroSchema());
@@ -90,11 +92,13 @@ public class BigQuerySinkConfig {
             BigQueryConnectOptions connectOptions,
             DeliveryGuarantee deliveryGuarantee,
             BigQuerySchemaProvider schemaProvider,
-            BigQueryProtoSerializer serializer) {
+            BigQueryProtoSerializer serializer,
+            boolean enableTableAutoCreate) {
         this.connectOptions = connectOptions;
         this.deliveryGuarantee = deliveryGuarantee;
         this.schemaProvider = schemaProvider;
         this.serializer = serializer;
+        this.enableTableAutoCreate = enableTableAutoCreate;
     }
 
     public BigQueryConnectOptions getConnectOptions() {
@@ -113,6 +117,10 @@ public class BigQuerySinkConfig {
         return schemaProvider;
     }
 
+    public boolean enableTableAutoCreate() {
+        return enableTableAutoCreate;
+    }
+
     /** Builder for BigQuerySinkConfig. */
     public static class Builder {
 
@@ -121,6 +129,7 @@ public class BigQuerySinkConfig {
         private BigQuerySchemaProvider schemaProvider;
         private BigQueryProtoSerializer serializer;
         private StreamExecutionEnvironment env;
+        private boolean enableTableAutoCreate;
 
         public Builder connectOptions(BigQueryConnectOptions connectOptions) {
             this.connectOptions = connectOptions;
@@ -142,6 +151,11 @@ public class BigQuerySinkConfig {
             return this;
         }
 
+        public Builder enableTableAutoCreate(boolean enableTableAutoCreate) {
+            this.enableTableAutoCreate = enableTableAutoCreate;
+            return this;
+        }
+
         public Builder streamExecutionEnvironment(
                 StreamExecutionEnvironment streamExecutionEnvironment) {
             this.env = streamExecutionEnvironment;
@@ -153,7 +167,11 @@ public class BigQuerySinkConfig {
                 validateStreamExecutionEnvironment(env);
             }
             return new BigQuerySinkConfig(
-                    connectOptions, deliveryGuarantee, schemaProvider, serializer);
+                    connectOptions,
+                    deliveryGuarantee,
+                    schemaProvider,
+                    serializer,
+                    enableTableAutoCreate);
         }
     }
 
@@ -164,13 +182,15 @@ public class BigQuerySinkConfig {
     public static BigQuerySinkConfig forTable(
             BigQueryConnectOptions connectOptions,
             DeliveryGuarantee deliveryGuarantee,
-            LogicalType logicalType) {
+            LogicalType logicalType,
+            boolean enableTableAutoCreate) {
         return new BigQuerySinkConfig(
                 connectOptions,
                 deliveryGuarantee,
                 new BigQuerySchemaProviderImpl(
                         BigQueryTableSchemaProvider.getAvroSchemaFromLogicalSchema(logicalType)),
-                new RowDataToProtoSerializer());
+                new RowDataToProtoSerializer(),
+                enableTableAutoCreate);
     }
 
     public static void validateStreamExecutionEnvironment(StreamExecutionEnvironment env) {

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/serializer/AvroToProtoSerializer.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/serializer/AvroToProtoSerializer.java
@@ -94,6 +94,11 @@ public class AvroToProtoSerializer extends BigQueryProtoSerializer<GenericRecord
         }
     }
 
+    @Override
+    public Schema getAvroSchema(GenericRecord record) {
+        return record.getSchema();
+    }
+
     /**
      * Function to convert a Generic Avro Record to Dynamic Message to write using the Storage Write
      * API.

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/serializer/BigQueryProtoSerializer.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/serializer/BigQueryProtoSerializer.java
@@ -18,6 +18,7 @@ package com.google.cloud.flink.bigquery.sink.serializer;
 
 import com.google.cloud.flink.bigquery.sink.exceptions.BigQuerySerializationException;
 import com.google.protobuf.ByteString;
+import org.apache.avro.Schema;
 
 import java.io.Serializable;
 
@@ -40,8 +41,18 @@ public abstract class BigQueryProtoSerializer<IN> implements Serializable {
     public abstract ByteString serialize(IN record) throws BigQuerySerializationException;
 
     /**
+     * Derives avro's {@link Schema} describing the data record. This is primarily used by the sink
+     * to infer schema for creating new destination BigQuery table if one doesn't already exist.
+     *
+     * @param record Record to check for schema
+     * @return Schema.
+     */
+    public abstract Schema getAvroSchema(IN record);
+
+    /**
      * Initializes the serializer with a BigQuery table schema. This will be called once for every
-     * serializer instance before its first serialize call.
+     * serializer instance before its first serialize call. Override with custom implementation for
+     * serializers corresponding to specific data types.
      *
      * @param schemaProvider BigQuery table's schema information.
      */

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/serializer/BigQuerySchemaProvider.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/serializer/BigQuerySchemaProvider.java
@@ -50,4 +50,12 @@ public interface BigQuerySchemaProvider extends Serializable {
      * @return AvroSchema
      */
     Schema getAvroSchema();
+
+    /**
+     * Returns true is BigQuery table's schema is known, else false. Schema can be unknown due to
+     * very plausible reasons like table does not exist.
+     *
+     * @return boolean
+     */
+    boolean schemaUnknown();
 }

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/serializer/BigQueryTableSchemaProvider.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/serializer/BigQueryTableSchemaProvider.java
@@ -25,7 +25,9 @@ import com.google.api.client.util.Preconditions;
 import com.google.api.services.bigquery.model.TableSchema;
 import com.google.cloud.flink.bigquery.common.config.BigQueryConnectOptions;
 import com.google.cloud.flink.bigquery.common.config.CredentialsOptions;
+import com.google.cloud.flink.bigquery.common.utils.SchemaTransform;
 import com.google.cloud.flink.bigquery.services.BigQueryServices;
+import com.google.cloud.flink.bigquery.services.BigQueryUtils;
 import com.google.cloud.flink.bigquery.table.config.BigQueryTableConfig;
 import org.apache.avro.Schema;
 
@@ -86,10 +88,10 @@ public class BigQueryTableSchemaProvider {
         // Translate to connect Options
         BigQueryConnectOptions connectOptions = getConnectOptionsFromTableConfig(tableConfig);
         // Obtain the desired BigQuery Table Schema
-        TableSchema bigQueryTableSchema =
-                BigQuerySchemaProviderImpl.getTableSchemaFromOptions(connectOptions);
+        TableSchema bigQueryTableSchema = BigQueryUtils.getTableSchema(connectOptions);
         // Obtain Avro Schema
-        Schema avroSchema = BigQuerySchemaProviderImpl.getAvroSchema(bigQueryTableSchema);
+        Schema avroSchema =
+                SchemaTransform.toGenericAvroSchema("root", bigQueryTableSchema.getFields());
         // Convert to Table API Schema
         org.apache.flink.table.api.Schema tableApiSchema =
                 getTableApiSchemaFromAvroSchema(avroSchema);

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/serializer/RowDataToProtoSerializer.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/serializer/RowDataToProtoSerializer.java
@@ -35,6 +35,7 @@ import com.google.protobuf.Descriptors;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.DynamicMessage;
+import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -87,6 +88,12 @@ public class RowDataToProtoSerializer extends BigQueryProtoSerializer<RowData> {
                             record, e.getMessage()),
                     e);
         }
+    }
+
+    @Override
+    public Schema getAvroSchema(RowData record) {
+        // TODO
+        return null;
     }
 
     public Object toProtoValue(

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryDefaultWriter.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryDefaultWriter.java
@@ -77,9 +77,7 @@ public class BigQueryDefaultWriter<IN> extends BaseWriter<IN> {
      */
     @Override
     public void write(IN element, Context context) {
-        totalRecordsSeen++;
-        numberOfRecordsSeenByWriter.inc();
-        numberOfRecordsSeenByWriterSinceCheckpoint.inc();
+        super.write(element, context);
         try {
             ByteString protoRow = getProtoRow(element);
             if (!fitsInAppendRequest(protoRow)) {
@@ -92,7 +90,11 @@ public class BigQueryDefaultWriter<IN> extends BaseWriter<IN> {
         }
     }
 
-    /** Overwriting flush() method for updating Flink Metrics in at-least-once Approach. */
+    /**
+     * Overwriting flush() method for updating Flink Metrics in at-least-once Approach.
+     *
+     * @param endOfInput
+     */
     @Override
     public void flush(boolean endOfInput) {
         super.flush(endOfInput);

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSink.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSink.java
@@ -53,8 +53,10 @@ public class BigQueryDynamicTableSink implements DynamicTableSink {
             LogicalType logicalType,
             Integer parallelism) {
         this.logicalType = logicalType;
+        // TODO
+        // Collect tableAutoCreate flag
         this.sinkConfig =
-                BigQuerySinkConfig.forTable(connectOptions, deliveryGuarantee, logicalType);
+                BigQuerySinkConfig.forTable(connectOptions, deliveryGuarantee, logicalType, false);
         this.parallelism = parallelism;
     }
 

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/fakes/StorageClientFaker.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/fakes/StorageClientFaker.java
@@ -186,6 +186,11 @@ public class StorageClientFaker {
                                                 BigQueryPartitionUtils.PartitionStatus.COMPLETED))
                         .collect(Collectors.toList());
             }
+
+            @Override
+            public Boolean tableExists(String dataset, String table) {
+                return Boolean.TRUE;
+            }
         }
 
         static class FaultyIterator<T> implements Iterator<T> {
@@ -905,6 +910,11 @@ public class StorageClientFaker {
             @Override
             public TableSchema getTableSchema(String project, String dataset, String table) {
                 return SIMPLE_BQ_TABLE_SCHEMA_TABLE;
+            }
+
+            @Override
+            public Boolean tableExists(String dataset, String table) {
+                return Boolean.TRUE;
             }
         }
     }

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/serializer/FakeBigQuerySerializer.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/serializer/FakeBigQuerySerializer.java
@@ -18,6 +18,7 @@ package com.google.cloud.flink.bigquery.sink.serializer;
 
 import com.google.cloud.flink.bigquery.sink.exceptions.BigQuerySerializationException;
 import com.google.protobuf.ByteString;
+import org.apache.avro.Schema;
 
 /** Mock serializer for Sink unit tests. */
 public class FakeBigQuerySerializer extends BigQueryProtoSerializer {
@@ -53,6 +54,11 @@ public class FakeBigQuerySerializer extends BigQueryProtoSerializer {
             throw new BigQuerySerializationException("Fake error for testing");
         }
         return serializeResult;
+    }
+
+    @Override
+    public Schema getAvroSchema(Object record) {
+        return null;
     }
 
     @Override

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/serializer/TestSchemaProvider.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/serializer/TestSchemaProvider.java
@@ -43,7 +43,13 @@ public class TestSchemaProvider implements BigQuerySchemaProvider {
         return this.descriptor;
     }
 
+    @Override
     public Schema getAvroSchema() {
         return this.schema;
+    }
+
+    @Override
+    public boolean schemaUnknown() {
+        return false;
     }
 }

--- a/flink-connector-bigquery-common/src/main/java/com/google/cloud/flink/bigquery/common/utils/BigQueryTableInfo.java
+++ b/flink-connector-bigquery-common/src/main/java/com/google/cloud/flink/bigquery/common/utils/BigQueryTableInfo.java
@@ -2,6 +2,7 @@ package com.google.cloud.flink.bigquery.common.utils;
 
 import com.google.api.services.bigquery.model.TableSchema;
 import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.Table;
 import com.google.cloud.bigquery.TableId;
 
 import java.util.Optional;
@@ -32,5 +33,25 @@ public class BigQueryTableInfo {
                                         String.format(
                                                 "The provided table %s.%s.%s does not exists.",
                                                 project, dataset, table)));
+    }
+
+    /**
+     * Function to identify if a BigQuery table exists.
+     *
+     * @param client {@link BigQuery} Object containing the BigQuery Client.
+     * @param dataset Dataset ID containing the Table.
+     * @param tableName Table Name.
+     * @return Boolean {@code TRUE} if the table exists or {@code FALSE} if it does not.
+     */
+    public static Boolean tableExists(BigQuery client, String dataset, String tableName) {
+        try {
+            Table table = client.getTable(TableId.of(dataset, tableName));
+            return (table != null && table.exists());
+        } catch (Exception e) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "The provided table %s.%s not found. %s",
+                            dataset, tableName, e.toString()));
+        }
     }
 }

--- a/flink-connector-bigquery-common/src/main/java/com/google/cloud/flink/bigquery/services/BigQueryServices.java
+++ b/flink-connector-bigquery-common/src/main/java/com/google/cloud/flink/bigquery/services/BigQueryServices.java
@@ -232,5 +232,14 @@ public interface BigQueryServices extends Serializable {
          * @return The dry run job's information.
          */
         Job dryRunQuery(String projectId, String query);
+
+        /**
+         * Function to identify if a BigQuery table exists.
+         *
+         * @param dataset The BigQuery dataset.
+         * @param table The BigQuery table name.
+         * @return Boolean {@code TRUE} if the table exists or {@code FALSE} if it does not.
+         */
+        Boolean tableExists(String dataset, String table);
     }
 }

--- a/flink-connector-bigquery-common/src/main/java/com/google/cloud/flink/bigquery/services/BigQueryServicesImpl.java
+++ b/flink-connector-bigquery-common/src/main/java/com/google/cloud/flink/bigquery/services/BigQueryServicesImpl.java
@@ -514,6 +514,11 @@ public class BigQueryServicesImpl implements BigQueryServices {
             }
         }
 
+        @Override
+        public Boolean tableExists(String dataset, String table) {
+            return BigQueryTableInfo.tableExists(bigQuery, dataset, table);
+        }
+
         static List<String> processErrorMessages(List<ErrorProto> errors) {
             return errors.stream()
                     .map(

--- a/flink-connector-bigquery-common/src/main/java/com/google/cloud/flink/bigquery/services/BigQueryUtils.java
+++ b/flink-connector-bigquery-common/src/main/java/com/google/cloud/flink/bigquery/services/BigQueryUtils.java
@@ -30,7 +30,10 @@ import com.google.api.services.bigquery.model.JobConfiguration;
 import com.google.api.services.bigquery.model.JobConfigurationQuery;
 import com.google.api.services.bigquery.model.JobReference;
 import com.google.api.services.bigquery.model.Table;
+import com.google.api.services.bigquery.model.TableSchema;
 import com.google.auth.http.HttpCredentialsAdapter;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.flink.bigquery.common.config.BigQueryConnectOptions;
 import com.google.cloud.flink.bigquery.common.config.CredentialsOptions;
 import dev.failsafe.Failsafe;
 import dev.failsafe.FailsafeExecutor;
@@ -186,5 +189,29 @@ public class BigQueryUtils {
                                 .get(projectId, datasetId, tableId)
                                 .setPrettyPrint(false)
                                 .execute());
+    }
+
+    /**
+     * Function to derive TableSchema from Connection Options for a Bigquery Table.
+     *
+     * @param connectOptions {@link BigQueryConnectOptions}
+     * @return {@link TableSchema} obtained for the table.
+     */
+    public static TableSchema getTableSchema(BigQueryConnectOptions connectOptions) {
+        BigQueryServices.QueryDataClient queryDataClient =
+                BigQueryServicesFactory.instance(connectOptions).queryClient();
+        return queryDataClient.getTableSchema(
+                connectOptions.getProjectId(),
+                connectOptions.getDataset(),
+                connectOptions.getTable());
+    }
+
+    public static boolean tableExists(BigQueryConnectOptions connectOptions) {
+        // TODO
+        return false;
+    }
+
+    public static void createTable(BigQueryConnectOptions connectOptions, Schema schema) {
+        // TODO
     }
 }

--- a/flink-connector-bigquery-common/src/main/java/com/google/cloud/flink/bigquery/services/BigQueryUtils.java
+++ b/flink-connector-bigquery-common/src/main/java/com/google/cloud/flink/bigquery/services/BigQueryUtils.java
@@ -207,8 +207,9 @@ public class BigQueryUtils {
     }
 
     public static boolean tableExists(BigQueryConnectOptions connectOptions) {
-        // TODO
-        return false;
+        BigQueryServices.QueryDataClient queryDataClient =
+                BigQueryServicesFactory.instance(connectOptions).queryClient();
+        return queryDataClient.tableExists(connectOptions.getDataset(), connectOptions.getTable());
     }
 
     public static void createTable(BigQueryConnectOptions connectOptions, Schema schema) {


### PR DESCRIPTION
Added functionality to check if a table already exists.

This check is performed:
* During the initial population of the properties of ```BigQuerySchemaProviderImpl```
* During the first ```append()``` request, before attempting to create a table.